### PR TITLE
sudo pip is strongly discouraged

### DIFF
--- a/Developers/counterparty_lib.md
+++ b/Developers/counterparty_lib.md
@@ -11,24 +11,29 @@
 
 * [Patched Bitcoin Core](bitcoin_core.md)
 * [Windows‐specific](windows.md)
+* Python 3
 
 
 ## Installation
 
-`$ sudo pip3 install counterparty-lib`
+`counterparty-lib` is distributed on [Python Packaging Index](https://pypi.python.org/pypi/counterparty-lib/).
 
-or
+Please refer to [Python package installation tutorial](http://packaging.python.org/) for detailed instructions how to install Python packages on your system. For software development installations [creating virtualenv](https://packaging.python.org/en/latest/projects.html#virtualenv) is recommended.
+
+`$ pip3 install counterparty-lib`
+
+or for the git master development installation:
 
 ```
 $ git clone https://github.com/CounterpartyXCP/counterpartyd.git
 $ cd counterpartyd/
-$ python3 setup.py install`
+$ python3 setup.py develop
 ```
 
 
 ## Upgrades
 
-`$ sudo pip3 install --upgrade counterparty-lib`
+`$ pip3 install --upgrade counterparty-lib`
 
 or
 


### PR DESCRIPTION
sudo pip installations are discouraged as system-wide Python installation is not intended for development or application testing purposes. 

This patch clarifies some Python packaging points, encourages virtualenv use and removes `sudo pip` as best practices violation.

For further information:

http://packaging.python.org/

http://opensourcehacker.com/2012/09/16/recommended-way-for-sudo-free-installation-of-python-software-with-virtualenv/