### PR TITLE
Add --fee-fraction=0.01 to broadcast

### DIFF
--- a/CLI/examples.md
+++ b/CLI/examples.md
@@ -133,7 +133,7 @@ Broadcast
 ----------------------------------------
 
     broadcast --source=mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns --text="Bitcoin price feed" \
-    --value=825.22 --fee-multiplier=0.001
+    --value=825.22 --fee-multiplier=0.001 --fee-fraction=0.01
 
 **Note:** for some users counterpartyd has trouble parsing spaces in the
 `--text` argument. One workaround is to add an additional set of quotes.


### PR DESCRIPTION
It seems required, please verify on a non-Windows system as well (at the moment `broadcast` seems to be broken in the CLI so I can't verify myself)
See: https://github.com/CounterpartyXCP/counterpartyd/issues/98#issuecomment-69380730