### PR TITLE
Changing "are are" to "are"

### DIFF
--- a/Developers/API.md
+++ b/Developers/API.md
@@ -359,7 +359,7 @@ Examples:
 
 ###floats
 
-Floats are are ratios or floating point values with six decimal places of precision, used in bets and dividends.
+Floats are ratios or floating point values with six decimal places of precision, used in bets and dividends.
 
 
 ##Miscellaneous


### PR DESCRIPTION
Simple typo fix to the documentation.