### PR TITLE
rename d to cli

### DIFF
--- a/CLI/examples.md
+++ b/CLI/examples.md
@@ -156,7 +156,7 @@ Broadcast
 
 `broadcast --source=mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns --text="Bitcoin price feed" --value=825.22 --fee-multiplier=0.001`
 
-**Note:** for some users counterpartyd has trouble parsing spaces in the
+**Note:** for some users counterparty-cli has trouble parsing spaces in the
 `--text` argument. One workaround is to add an additional set of quotes.
 For example, `--text='"Bitcoin price feed"'`. This may not work on
 Windows due to Python/Windows issues unrelated to Counterparty. Another 
@@ -214,7 +214,7 @@ Dividend
 * --fee = the exact BTC fee to be paid to miners
 
 To pay dividends in BTC, you should, for now, just use a regular Bitcoin
-client, coupled with the output from `counterpartyd asset ASSET`, which
+client, coupled with the output from `counterparty-cli asset ASSET`, which
 will list all of the shareholders (and their holdings) of ASSET.
 
     dividend --source=mtQheFaSfWELRB2MyMBaiWjdDm6ux9Ezns --quantity-per-share=1 \


### PR DESCRIPTION
I renamed instances of counterpartyd to counterparty-cli. I assume the format stayed the same, if not, please review.