### PR TITLE
Remove 14Tf35AovvRVURzd623q5i9kry2EW8WzyL

### DIFF
--- a/Developers/bounties.md
+++ b/Developers/bounties.md
@@ -1,7 +1,5 @@
 # Counterparty Bug Bounty Program
 
-**Donation Address: 14Tf35AovvRVURzd623q5i9kry2EW8WzyL **
-
 According to [Linus’ Law](http://en.wikipedia.org/wiki/Linus), “given enough eyeballs, all bugs are shallow”. That’s one of the reasons why Counterparty’s source code is publicly available; but merely making the source code available doesn't accomplish anything if people don’t read it!
 
 For this reason, Counterparty has a series of bug bounties. Similar to the bounties offered by [Mozilla](http://www.mozilla.org/security/bug-bounty.html) and [Google](http://blog.chromium.org/2010/01/encouraging-more-chromium-security.html), Counterparty bug bounties provide an opportunity for people who find bugs to be compensated. Unlike those programs, however, Counterparty’s bug bounties are not limited to security vulnerabilities.


### PR DESCRIPTION
This address has been advertised as a place to donate funds for bounties, however, it has not been active since 2014. Suggest removing.