### PR TITLE
Update Doc's page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Official Documentation of the Counterparty Project
 
-The markdown documentation in this repository is rerendered hourly and made available at the [Counterparty documentation site](http://counterparty.io/docs/).
+The markdown documentation in this repository is rerendered hourly and made available at the [Counterparty documentation site](https://docs.counterparty.io/).


### PR DESCRIPTION
![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/1ded9527-6466-4966-a6b1-9f76e7077699)
Docs Button on Counterparty.io is now https://docs.counterparty.io/ and the former link http://counterparty.io/docs/ does not show the information correctly