### PR TITLE
Updating "Getting Support on the Forums"

### DIFF
--- a/Basics/create_support_ticket.md
+++ b/Basics/create_support_ticket.md
@@ -1,7 +1,7 @@
 Getting Support on the Forums
 -------------------------------
 
-Counterparty is an open-source, non-profit project which relies heavily on its community. This makes the official public forum the best place to provide support for any issues encountered while using Counterparty software or protocol.
+Counterparty is an open-source, non-profit project which relies heavily on its community. This makes the [official public forum](https://forums.counterparty.io/) the best place to provide support for any issues encountered while using Counterparty software or protocol.
 
 There are two types of support on the forum: Public and Private
 
@@ -16,21 +16,21 @@ To get public support on the forum:
 addressed or if there is a knowledge-base article explaining the
 solution in more detail
 
-![](/_images/support_1.png)
+![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/d547582a-102d-4813-ba28-166bd09aa3b7)
 
 - If there is already an open topic with the same/similar issue, post your question/comment there (or use the solution provided)
 
 - Make sure to subscribe to the topic by selecting 'Watching' from the picker at the bottom of the page
 
-![](/_images/support_2.png)
+![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/a1b043d6-1e86-4672-a089-28e22db2ad65)
 
-- If you are not able to find a similar topic already created, go to https://counterpartytalk.org/c/support and click on New Topic
+- If you are not able to find a similar topic already created, click on New Topic
 
-![](/_images/support_3.png)
+![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/bdb1b78c-7968-4f79-abba-3eab536e1d93)
 
 - Select the appropriate subcategory (Counterwallet, Server or GUI) and type in your message
 
-![](/_images/support_4.png)
+![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/aef7808d-edb0-4289-ab3a-0132c67fa2ec)
 
 - When creating a new topic, the notification setting will automatically be set to 'Watching', which means you will be notified via email as soon as someone replies (please add noreply@counterparty.io to your email contact list)
 
@@ -38,20 +38,15 @@ solution in more detail
 
 ##Private Support
 
-In case you have a question for support that you do not want to ask publicly, or simply want your problem to be addressed privately, you can send a private message to the 'Support' group. This message will only be visible to the members of the Counterparty support team.
+In case you have a question for support that you do not want to ask publicly, or simply want your problem to be addressed privately, you can send a private message to the administrator or moderator of the forums. This message will only be visible to either the current Admin or current Moderator.
 
 To send a private message to support:
 
-- Go to Messages and click on New Message
+- Go to the [About page](https://forums.counterparty.io/about) on the forum, find either the Admin or the Moderator and click 'Message'
 
-![](/_images/support_5.png)
+![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/12673a47-f854-4310-8957-28bc9b8219f4)
 
-
-![](/_images/support_6.png)
-
-- In the 'Add User' field type 'Support' (you should see the names of the group members)
-
-![](/_images/support_7.png)
+![image](https://github.com/CounterpartyXCP/Documentation/assets/136373423/6a35f435-4860-4dfb-8b92-ee38721e482b)
 
 - Enter your message and click Send.
-- As soon as a reply is posted by one of the support members you will get an email notification (please add noreply@counterparty.io to your email contact list).
+- As soon as a reply by one of the support members is sent, you will get an email notification (please add noreply@counterparty.io to your email contact list).


### PR DESCRIPTION
Old documentation had no current link to the Counterparty Forums and said "Support" area was for Private Support when it is in fact public. 

Also updated the screenshots to the new UI of the forums, as well as updated the Private Support to be messaging the current Admin and Moderator of the forums.