### PR TITLE
update Docusaurus API docs

### DIFF
--- a/docs/advanced/federated-node/getting-started.md
+++ b/docs/advanced/federated-node/getting-started.md
@@ -28,11 +28,11 @@ Please note that Federated Node should not be installed on a system which alread
 
 - **Memory**: 4GB RAM (`bitcoind`, `counterparty-server` only), 8GB+ RAM (full stack)
 - **Disk space:** The exact disk space required will be dependent on what services are run on the node:
-    - For ``bitcoin`` databases: **~361GB** (mainnet), **~32GB** (testnet)
-    - For ``addrindexrs`` database: **~63GB** (mainnet), **~6GB** (testnet)
-    - For ``counterparty`` databases: **~5GB** (mainnet), **~1GB** (testnet)
-    - For ``armory_utxsvr``: **~291GB** (mainnet), **~26GB** (testnet)
+    - For ``bitcoin`` databases: **~610GB** (mainnet), **~37GB** (testnet)
+    - For ``addrindexrs`` database: **~130GB** (mainnet), **~9GB** (testnet)
+    - For ``counterparty`` databases: **~9GB** (mainnet), **~2GB** (testnet)
+    - For ``armory_utxsvr``: **~650GB** (mainnet), **~40GB** (testnet)
 - **OS:** *Please note that Ubuntu Linux is the recommended OS at this time, as most of our testing is performed on it. Windows and OS X support is considered in BETA.*
-    - **Linux**: We recommend Ubuntu 20.10 64-bit, but other, modern versions of Linux should work, as long as they support the newest released version of Docker
+    - **Linux**: We recommend Ubuntu 22.04 LTS 64-bit, but other, modern versions of Linux should work, as long as they support the newest released version of Docker
     - **Windows**: Windows 7 or higher, or Server 2008 or higher. 64-bit required
     - **OS X**: 10.8 "Mountain Lion" or higher

--- a/docs/advanced/federated-node/pre-installation.md
+++ b/docs/advanced/federated-node/pre-installation.md
@@ -48,15 +48,5 @@ Make sure you have Python 3.5. (Ubuntu 14.04 for instance uses Python 3.4 by def
 
 ```
 sudo apt-get update && sudo apt-get upgrade
-sudo apt-get -y install git curl coreutils
-```
-
-Install docker-ce and docker-compose (see [here](https://docs.docker.com/compose/install/) for more info, here we use v1.16.1):
-
-```
-sudo -i # become root
-curl -fsSL https://get.docker.com/ | sh
-curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-exit # leave root shell
+sudo apt-get -y install git curl coreutils docker.io docker-compose
 ```

--- a/docs/develop/api/api.md
+++ b/docs/develop/api/api.md
@@ -592,6 +592,7 @@ Issue a new asset, issue more of an existing asset, lock an asset, reset existin
   * *NOTE: **reset** is only possible when no supply is issued, or when the asset owner has control of 100% of the supply.*
   * *NOTE: When resetting an assets supply, **transfer_destination** will not work in the same issuance as **reset** .*
   * *NOTE: Additional (advanced) parameters for this call are documented [here](#advanced-create_-parameters).*
+  * *NOTE: When resetting an assets supply, **lock** and **transfer_destination** will not work in the same issuance as **reset** .*
 
 **Return:**
 

--- a/docs/develop/api/api.md
+++ b/docs/develop/api/api.md
@@ -547,12 +547,23 @@ of give_quantity to ease dispenser operation.
   * **open_address** (*string*): The address that you would like to open the dispenser on.
   * **oracle_address** (*string*): The address that you would like to use as a price oracle for this dispenser.
   * **status** (*integer*): The state of the dispenser. 0 for open, 1 for open using open_address, 10 for closed.
-  * *NOTE: When specifying an **oracle_address**, **mainchainrate** format becomes X.XX (fiat) (ex. 1500 = 15.00).*
   * *NOTE: Additional (advanced) parameters for this call are documented [here](#advanced-create_-parameters).*
 
 **Return:**
 
   The unsigned transaction, as an hex-encoded string. Must be signed before being broadcast: see [here](#signing-transactions-before-broadcasting) for more information.
+
+**Notes:**
+  * When specifying an **oracle_address**, **mainchainrate** format becomes X.XX (fiat) (ex. 1500 = 15.00).
+  * Dispensers can be opened on **`EMPTY`** addresses (address with no BTC or XCP history)
+  * **`origin`** address is the **`source`** address that opens a dispenser on an **`EMPTY`** address
+  * Dispensers can be opened, closed, and refilled via **`source`** or **`origin`** addresses
+  * When closing a dispenser from **`origin`**, escrowed dispenser funds are credited to **`origin`** address
+  * Use **`open_address`** param to operate on a dispenser from **`origin`** address  
+  * Dispensers have a `MAX_DISPENSE` limit of 1,000
+  * Dispensers `MAX_DISPENSE` can be reset via a dispenser refill
+  * Dispensers have a `MAX_REFILL` limit of 5
+  * Dispensers have a `CLOSE` delay of 5 blocks
 
 ### create_dividend
 


### PR DESCRIPTION
- Added note about transfer/lock not working with reset in issuances
- Updated disk requirements and suggested ubuntu version
- Updated preferred docker install method
- Update dispenser API docs to indicate new `origin` field and dispenser limitations