### PR TITLE
Point API documentation links to apidocs.counterparty.io

### DIFF
--- a/docs/advanced/api-v1/api-v1-spec.md
+++ b/docs/advanced/api-v1/api-v1-spec.md
@@ -731,7 +731,6 @@ By default the default value of the ``encoding`` parameter detailed above is ``a
 
 ## REST API Function Reference
 
-The REST API documentation is hosted both on our webiste and on a new API documentation platform called apiary.io. This experimental documentation, complementary to the one in this document, is located [here](http://docs.counterpartylib.apiary.io/#).
 
 ### get
 

--- a/docs/advanced/api-v2/node-api.md
+++ b/docs/advanced/api-v2/node-api.md
@@ -6,4 +6,4 @@ title: API v2
 
 The Counterparty Core API is the recommended way to query the state of a Counterparty node. All other methods have no official support.
 
-Please see [Apiary](https://counterpartycore.docs.apiary.io/) for interactive documentation.
+Please see the [Counterparty Core API reference](https://apidocs.counterparty.io/) for interactive documentation.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,7 +40,7 @@ module.exports = {
           position: 'right',
         },
         {
-          href: 'https://counterpartycore.docs.apiary.io/',
+          href: 'https://apidocs.counterparty.io/',
           label: 'API Documentation',
           position: 'right',
         },


### PR DESCRIPTION
Apiary (counterpartycore.docs.apiary.io) no longer renders our docs (HTTP 500) and Oracle is retiring the platform. The Counterparty Core API reference is moving to https://apidocs.counterparty.io/ (OpenAPI 3.1 + Scalar on GitHub Pages; counterparty-core PR to follow).

- Update the navbar and node API page links
- Remove a dead apiary.io link from the historical v1 spec page

Marked as draft: merge once apidocs.counterparty.io is live (after the counterparty-core PR merges to master and Pages deploys).